### PR TITLE
Added Default Faust paths for OSX build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ option(JUCE_BUILD_EXAMPLES "Build JUCE Examples" OFF)
 
 add_subdirectory(JUCE)
 
+include_directories(
+	/usr/local/include
+)
+
 
 juce_add_plugin("${BaseTargetName}"
     COMPANY_NAME "Glocq"
@@ -75,5 +79,5 @@ target_link_libraries(${BaseTargetName} PRIVATE
     juce::juce_recommended_config_flags
     juce::juce_recommended_lto_flags
     juce::juce_recommended_warning_flags
-    faust
+    -L/usr/local/lib faust
 )


### PR DESCRIPTION
The CMakeLists.txt file doesn't work as is in OS X given that the default path for Faust is not considered in the project structure.

Adding an include_directores directive seems like the right approach and link it to the default path.
Also the path of the library itself is not found, hence the explicit description of the location of the library.

I'm not sure if this last one breaks the linux install!