### PR TITLE
Additions to CMakeLists.txt to better organize information in IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set (BaseTargetName Amati)
 
 # The following few lines are copied from https://github.com/eyalamirmusic/JUCECmakeRepoPrototype
 # Being a Linux user, I don't really know to what extent they are necessary, or whether they are even correct.
-# If you are building on another OS, please tell me aout your experience!
+# If you are building on another OS, please tell me about your experience!
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ include_directories(
 	/usr/local/include
 )
 
-set(Formats AU VST3 AUv3 Standalone)
+set(Formats VST3 AU Standalone)
 
 
 juce_add_plugin(${BaseTargetName}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,28 @@ endif()
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 #Adds all the module sources so they appear correctly in the IDE
-set_property(GLOBAL PROPERTY USE_FOLDERS YES)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 option(JUCE_ENABLE_MODULE_SOURCE_GROUPS "Enable Module Source Groups" ON)
+
+# By default we don't want Xcode schemes to be made for modules, etc
+set(CMAKE_XCODE_GENERATE_SCHEME OFF)
 
 #-------------------------------------------------------------------------------
 
 option(JUCE_BUILD_EXTRAS "Build JUCE Extras" OFF)
 option(JUCE_BUILD_EXAMPLES "Build JUCE Examples" OFF)
+
+# Adds all the module sources so they appear correctly in the IDE
+# Must be set before JUCE is added as a sub-dir (or any targets are made)
+set_property(GLOBAL PROPERTY USE_FOLDERS YES)
+
+# This is a failed attempt to bury ALL_BUILD in Targets/
+# This should be called before any target is made
+# Bug in Xcode? https://gitlab.kitware.com/cmake/cmake/-/issues/21383
+set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "Targets")
+
+# Create a /Modules directory in the IDE with the JUCE Module code
+option(JUCE_ENABLE_MODULE_SOURCE_GROUPS "Show all module sources in IDE projects" ON)
 
 
 add_subdirectory(JUCE)
@@ -37,24 +52,36 @@ include_directories(
 	/usr/local/include
 )
 
+set(Formats AU VST3 AUv3 Standalone)
 
-juce_add_plugin("${BaseTargetName}"
+
+juce_add_plugin(${BaseTargetName}
     COMPANY_NAME "Glocq"
     IS_SYNTH FALSE
     NEEDS_MIDI_INPUT FALSE
     NEEDS_MIDI_OUTPUT FALSE
     IS_MIDI_EFFECT FALSE
-    EDITOR_WANTS_KEYBOARD_FOCUS FALSE
-    COPY_PLUGIN_AFTER_BUILD FALSE
+    EDITOR_WANTS_KEYBOARD_FOCUS TRUE
+    COPY_PLUGIN_AFTER_BUILD TRUE
     PLUGIN_MANUFACTURER_CODE L0cq # Not sure I understand what those
     PLUGIN_CODE Mati              # are about, I hope I'm doing it right
-    FORMATS AU VST3 Standalone
-    PRODUCT_NAME "Amati"
+    FORMATS ${Formats}
+    PRODUCT_NAME ${BaseTargetName}
 )
+
+# C++ std
+target_compile_features(${BaseTargetName} PRIVATE cxx_std_17)
 
 juce_generate_juce_header(${BaseTargetName})
 
-target_sources(${BaseTargetName} PRIVATE
+set(SourceFiles
+    Source/DebugComponent.h
+    Source/EditorComponent.h
+    Source/FaustCodeTokenizer.h
+    Source/FaustProgram.h
+    Source/ParamEditor.h
+    Source/PluginEditor.h
+    Source/PluginProcessor.h
     Source/DebugComponent.cpp
     Source/EditorComponent.cpp
     Source/FaustCodeTokenizer.cpp
@@ -63,6 +90,36 @@ target_sources(${BaseTargetName} PRIVATE
     Source/PluginEditor.cpp
     Source/PluginProcessor.cpp
 )
+
+target_sources(${BaseTargetName} PRIVATE ${SourceFiles})
+
+# No, we don't want our source buried in extra nested folders
+set_target_properties("${PROJECT_NAME}" PROPERTIES FOLDER "")
+
+# The source tree should uhhh, still look like the source tree, yo
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/Source PREFIX "" FILES ${SourceFiles})
+
+
+# This cleans up the folder organization, especially on Xcode.
+# It tucks the Plugin varieties into a "Targets" folder and generate an Xcode Scheme manually
+# Xcode scheme generation is turned off globally to limit noise from other targets
+# The non-hacky way of doing this is via the global PREDEFINED_TARGETS_FOLDER propety
+# However that doesn't seem to be working in Xcode
+# Not all plugin types (au, vst) available on each build type (win, macos, linux)
+foreach(target ${Formats} "All")
+    if(TARGET ${BaseTargetName}_${target})
+        set_target_properties(${BaseTargetName}_${target} PROPERTIES
+            # Tuck the actual plugin targets into a folder where they won't bother us
+            FOLDER "Targets"
+            
+            # MacOS only: Sets the default executable that Xcode will open on build
+            # For this exact path to to work, manually build the AudioPluginHost.xcodeproj in the JUCE subdir 
+            XCODE_SCHEME_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/JUCE/extras/AudioPluginHost/Builds/MacOSX/build/Debug/AudioPluginHost.app"
+            
+            # Let us build the target in Xcode 
+            XCODE_GENERATE_SCHEME ON)
+    endif()
+endforeach()
 
 target_compile_definitions(${BaseTargetName}
     PUBLIC

--- a/Source/DebugComponent.h
+++ b/Source/DebugComponent.h
@@ -28,9 +28,8 @@ class DebugComponent :
 {
 public:
     DebugComponent ();
-    ~DebugComponent () {};
 
-    void paint (juce::Graphics&) override {};
+    void paint (juce::Graphics&) override {}
     void resized () override;
 
     void logMessage (const juce::String&) override;

--- a/Source/EditorComponent.h
+++ b/Source/EditorComponent.h
@@ -28,9 +28,8 @@ class EditorComponent :
 {
 public:
     EditorComponent ();
-    ~EditorComponent () {};
 
-    void paint (juce::Graphics&) override {};
+    void paint (juce::Graphics&) override {}
     void resized () override;
 
     void startListeningToCompileButton (juce::Button::Listener*);

--- a/Source/FaustCodeTokenizer.cpp
+++ b/Source/FaustCodeTokenizer.cpp
@@ -246,7 +246,6 @@ struct FaustTokeniserFunctions
 
 //==============================================================================
 FaustTokeniser::FaustTokeniser() {}
-FaustTokeniser::~FaustTokeniser() {}
 
 int FaustTokeniser::readNextToken (CodeDocument::Iterator& source)
 {

--- a/Source/FaustCodeTokenizer.h
+++ b/Source/FaustCodeTokenizer.h
@@ -18,7 +18,6 @@ class FaustTokeniser   : public CodeTokeniser
 public:
   //==============================================================================
   FaustTokeniser();
-  ~FaustTokeniser();
   
   //==============================================================================
   int readNextToken (CodeDocument::Iterator&) override;

--- a/Source/FaustProgram.cpp
+++ b/Source/FaustProgram.cpp
@@ -29,7 +29,6 @@ bool FaustProgram::compileSource (juce::String source)
 {
     juce::Logger::getCurrentLogger() -> writeToLog ("Starting compilation...");
 
-    const char* argv[] = {""}; // compilation arguments
     std::string errorString;
 
     std::unique_ptr<llvm_dsp_factory> factory (createDSPFactoryFromString
@@ -37,7 +36,7 @@ bool FaustProgram::compileSource (juce::String source)
         "faust", // program name
         source.toStdString (),
         0, // number of arguments
-        argv,
+        nullptr,
         "", // compilation target; left empty to say we want to compile for this machine
         errorString
     ));

--- a/Source/FaustProgram.h
+++ b/Source/FaustProgram.h
@@ -40,7 +40,6 @@ private:
 public:
 
     FaustProgram (int sampRate);
-    ~FaustProgram ();
 
     bool compileSource (juce::String);
     int getParamCount ();
@@ -64,8 +63,8 @@ public:
 
 private:
 
-    llvm_dsp* dspInstance = nullptr;
-    APIUI* faustInterface = nullptr;
+    std::unique_ptr<llvm_dsp> dspInstance = nullptr;
+    std::unique_ptr<APIUI> faustInterface = nullptr;
     bool ready = false;
     int sampleRate;
 

--- a/Source/ParamEditor.h
+++ b/Source/ParamEditor.h
@@ -29,9 +29,8 @@ class ParamEditor :
 {
 public:
     ParamEditor ();
-    ~ParamEditor () {};
 
-    void paint (juce::Graphics&) override {};
+    void paint (juce::Graphics&) override {}
     void resized () override;
 
     void setValue (int, double);

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -47,7 +47,7 @@ public:
     void sliderDragStarted (juce::Slider*) override;
     void sliderDragEnded (juce::Slider*) override;
 
-    void timerCallback ();
+    void timerCallback () override;
 
 private:
     // This reference is provided as a quick way for your editor to


### PR DESCRIPTION
In general is just adding some organization instructions so that folders in an IDE show up properly.
Notable details include adding header files to source files: This is important so that an IDE can build "Counterpart" relationships between .h files and .cpp files
Formats were also separated as they are later used to move all those targets into a general Targets folder

Tested this in Xcode (It also seems to be working properly in VS2019 but couldn't build because of Faust dependencies)

Most of the changes come from suggestions on [this](https://forum.juce.com/t/cmake-examples-in-xcode/42188/4) discussion.